### PR TITLE
LICENSE bug

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -14,7 +14,7 @@ This pgEdge Community License Agreement Version 1.0 (the "**Agreement**") sets f
 
 **b.**  On each Software copy, Licensee shall reproduce and not remove or alter all pgEdge or third party copyright or other proprietary notices contained in the Software, and Licensee must provide the notice below with each copy.
 
-"This software is made available by pgEdge, Inc., under the terms of the pgEdge Community License Agreement, Version 1.0 located at https://www.pgEdge.com/pgEdge-community-license. BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT."
+"This software is made available by pgEdge, Inc., under the terms of the pgEdge Community License Agreement, Version 1.0 located at https://www.pgedge.com/communitylicense. BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT."
 
 **1.3 Licensee Modifications**. Licensee may add its own copyright notices to modifications made by Licensee and may provide additional or different license terms and conditions for use, reproduction, or distribution of Licensee's modifications. While redistributing the Software or modifications thereof, Licensee may choose to offer, for a fee or free of charge, support, warranty, indemnity, or other obligations.Licensee, and not pgEdge, will be responsible for any such obligations.
 


### PR DESCRIPTION
The link to the license on the pgEdge website is incorrect. Personally I like the URL you pointed at more than the actual url, so maybe it'd be better to fix the url in the website (with a 301 from the old to the new url), although if you are changing the website url, I'd probably also suggesting putting the 1.0 version number in the url, but lieu of any of that, the docs should point to the right place.