### PR TITLE
Fix MAXVALUE on snowflake-converted sequences.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,11 @@ DATA = snowflake--1.0.sql \
 	   snowflake--2.2.sql \
 	   snowflake--2.2--2.3.sql \
 	   snowflake--2.3.sql \
-	   snowflake--2.3--2.4.sql
+	   snowflake--2.3--2.4.sql \
+	   snowflake--2.4--2.5.sql
 PGFILEDESC = "snowflake - snowflake style IDs for PostgreSQL"
 
-REGRESS = conversion
+REGRESS = conversion maxvalue repair
 
 ifdef USE_PGXS
 PG_CONFIG = pg_config

--- a/expected/conversion.out
+++ b/expected/conversion.out
@@ -17,7 +17,7 @@ INSERT INTO t3 VALUES (DEFAULT);
 SELECT snowflake.convert_sequence_to_snowflake('t1'); -- ERROR, not a sequence
 ERROR:  Input value "public.t1" is not a valid convertable sequence
 SELECT snowflake.convert_sequence_to_snowflake('seq_1'); -- No associated relation found
-NOTICE:  ALTER SEQUENCE public.seq_1 NO CYCLE MAXVALUE 43
+NOTICE:  ALTER SEQUENCE public.seq_1 AS bigint NO CYCLE MAXVALUE 9223372036854775807
  convert_sequence_to_snowflake 
 -------------------------------
                              0
@@ -26,7 +26,7 @@ NOTICE:  ALTER SEQUENCE public.seq_1 NO CYCLE MAXVALUE 43
 SELECT snowflake.convert_sequence_to_snowflake('t1_x_seq');
 NOTICE:  EXECUTE ALTER TABLE public.t1 ALTER COLUMN x SET DATA TYPE int8
 NOTICE:  EXECUTE ALTER TABLE public.t1 ALTER COLUMN x SET DEFAULT snowflake.nextval('public.t1_x_seq'::regclass)
-NOTICE:  ALTER SEQUENCE public.t1_x_seq NO CYCLE MAXVALUE 2
+NOTICE:  ALTER SEQUENCE public.t1_x_seq AS bigint NO CYCLE MAXVALUE 9223372036854775807
  convert_sequence_to_snowflake 
 -------------------------------
                              1
@@ -36,7 +36,7 @@ SELECT snowflake.convert_sequence_to_snowflake('t2_x_seq');
 NOTICE:  Update pg_attribute: reset attidentity value for table public.t2, column x
 NOTICE:  EXECUTE ALTER TABLE public.t2 ALTER COLUMN x SET DATA TYPE int8
 NOTICE:  EXECUTE ALTER TABLE public.t2 ALTER COLUMN x SET DEFAULT snowflake.nextval('public.t2_x_seq'::regclass)
-NOTICE:  ALTER SEQUENCE public.t2_x_seq NO CYCLE MAXVALUE 2
+NOTICE:  ALTER SEQUENCE public.t2_x_seq AS bigint NO CYCLE MAXVALUE 9223372036854775807
  convert_sequence_to_snowflake 
 -------------------------------
                              1
@@ -46,7 +46,7 @@ SELECT snowflake.convert_sequence_to_snowflake('t3_x_seq');
 NOTICE:  Update pg_attribute: reset attidentity value for table public.t3, column x
 NOTICE:  EXECUTE ALTER TABLE public.t3 ALTER COLUMN x SET DATA TYPE int8
 NOTICE:  EXECUTE ALTER TABLE public.t3 ALTER COLUMN x SET DEFAULT snowflake.nextval('public.t3_x_seq'::regclass)
-NOTICE:  ALTER SEQUENCE public.t3_x_seq NO CYCLE MAXVALUE 2
+NOTICE:  ALTER SEQUENCE public.t3_x_seq AS bigint NO CYCLE MAXVALUE 9223372036854775807
  convert_sequence_to_snowflake 
 -------------------------------
                              1
@@ -55,7 +55,7 @@ NOTICE:  ALTER SEQUENCE public.t3_x_seq NO CYCLE MAXVALUE 2
 SELECT snowflake.convert_sequence_to_snowflake('t3_z_seq'); -- non-default attnum
 NOTICE:  EXECUTE ALTER TABLE public.t3 ALTER COLUMN z SET DATA TYPE int8
 NOTICE:  EXECUTE ALTER TABLE public.t3 ALTER COLUMN z SET DEFAULT snowflake.nextval('public.t3_z_seq'::regclass)
-NOTICE:  ALTER SEQUENCE public.t3_z_seq NO CYCLE MAXVALUE 2
+NOTICE:  ALTER SEQUENCE public.t3_z_seq AS bigint NO CYCLE MAXVALUE 9223372036854775807
  convert_sequence_to_snowflake 
 -------------------------------
                              1
@@ -114,7 +114,7 @@ ALTER TABLE t3 ALTER COLUMN y SET DEFAULT nextval('t3_y_seq'::regclass);
 SELECT snowflake.convert_sequence_to_snowflake('t3_y_seq');
 NOTICE:  EXECUTE ALTER TABLE public.t3 ALTER COLUMN y SET DATA TYPE int8
 NOTICE:  EXECUTE ALTER TABLE public.t3 ALTER COLUMN y SET DEFAULT snowflake.nextval('public.t3_y_seq'::regclass)
-NOTICE:  ALTER SEQUENCE public.t3_y_seq NO CYCLE MAXVALUE 3
+NOTICE:  ALTER SEQUENCE public.t3_y_seq AS bigint NO CYCLE MAXVALUE 9223372036854775807
  convert_sequence_to_snowflake 
 -------------------------------
                              1
@@ -162,7 +162,7 @@ SELECT * FROM t4;
 SELECT snowflake.convert_sequence_to_snowflake('favorite_seq');
 NOTICE:  EXECUTE ALTER TABLE public.t4 ALTER COLUMN x SET DATA TYPE int8
 NOTICE:  EXECUTE ALTER TABLE public.t4 ALTER COLUMN x SET DEFAULT snowflake.nextval('public.favorite_seq'::regclass)
-NOTICE:  ALTER SEQUENCE public.favorite_seq NO CYCLE MAXVALUE 2
+NOTICE:  ALTER SEQUENCE public.favorite_seq AS bigint NO CYCLE MAXVALUE 9223372036854775807
  convert_sequence_to_snowflake 
 -------------------------------
                              2
@@ -201,7 +201,7 @@ NOTICE:  EXECUTE ALTER TABLE public.t4 ALTER COLUMN x SET DATA TYPE int8
 NOTICE:  EXECUTE ALTER TABLE public.t4 ALTER COLUMN x SET DEFAULT snowflake.nextval('public.favorite_seq'::regclass)
 NOTICE:  EXECUTE ALTER TABLE public.t5 ALTER COLUMN x SET DATA TYPE int8
 NOTICE:  EXECUTE ALTER TABLE public.t5 ALTER COLUMN x SET DEFAULT snowflake.nextval('public.favorite_seq'::regclass)
-NOTICE:  ALTER SEQUENCE public.favorite_seq NO CYCLE MAXVALUE 3
+NOTICE:  ALTER SEQUENCE public.favorite_seq AS bigint NO CYCLE MAXVALUE 9223372036854775807
  convert_sequence_to_snowflake 
 -------------------------------
                              4
@@ -238,10 +238,19 @@ SELECT * FROM t6;
 
 SELECT snowflake.convert_sequence_to_snowflake('t6_x_seq');
 NOTICE:  EXECUTE ALTER TABLE public.t6 ALTER COLUMN x SET DEFAULT snowflake.nextval('public.t6_x_seq'::regclass)
-NOTICE:  ALTER SEQUENCE public.t6_x_seq NO CYCLE MAXVALUE 4
+NOTICE:  ALTER SEQUENCE public.t6_x_seq AS bigint NO CYCLE MAXVALUE 9223372036854775807
  convert_sequence_to_snowflake 
 -------------------------------
                              0
+(1 row)
+
+-- Start from a fresh millisecond so the counter base is 0 regardless of how
+-- the preceding calls happened to land in time. Without this the exact count
+-- values below depend on millisecond boundaries and the test is flaky.
+SELECT pg_sleep(0.5);
+ pg_sleep 
+----------
+ 
 (1 row)
 
 -- Get the count portion of the id.
@@ -267,6 +276,13 @@ SELECT ABS(snowflake.nextval('t6_x_seq') - snowflake.nextval('t6_x_seq'));
 
 -- If < 4096, will increment that amount
 ALTER SEQUENCE t6_x_seq INCREMENT 100 NO MAXVALUE;
+-- Again start from a fresh millisecond for a deterministic counter base.
+SELECT pg_sleep(0.5);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 SELECT snowflake.get_count(snowflake.nextval('t6_x_seq'))
 UNION ALL
 SELECT snowflake.get_count(snowflake.nextval('t6_x_seq'))
@@ -274,9 +290,9 @@ UNION ALL
 SELECT snowflake.get_count(snowflake.nextval('t6_x_seq'));
  get_count 
 -----------
-       104
-       204
-       304
+         0
+       100
+       200
 (3 rows)
 
 -- This will force the time ms portion to increment,

--- a/expected/maxvalue.out
+++ b/expected/maxvalue.out
@@ -1,0 +1,100 @@
+/*
+ * maxvalue.sql - regression for the SUP-140 dump/restore failure.
+ *
+ * Before the fix, convert_sequence_to_snowflake() set
+ *   ALTER SEQUENCE ... MAXVALUE (last_value + 1)
+ * which is fine for the snowflake.nextval() path (it bypasses MAXVALUE)
+ * but fatal for pg_dump/restore: the dump captures the resulting
+ * snowflake-sized last_value via pg_catalog.setval(...) and the
+ * restore is rejected with
+ *   ERROR: setval: value <big_snowflake_id> is out of bounds for
+ *          sequence "<seq>" (1..<small>)
+ *
+ * This test asserts that after conversion the sequence's max_value is
+ * the full bigint range (2^63-1).
+ */
+\set VERBOSITY terse
+SET snowflake.node = 1;
+CREATE EXTENSION snowflake;
+-- ----------------------------------------------------------------------
+-- 1. Customer reproducer: bigserial table, INSERT, convert.
+-- ----------------------------------------------------------------------
+CREATE TABLE orders (
+    id    bigserial PRIMARY KEY,
+    customer text   NOT NULL,
+    amount  numeric  NOT NULL
+);
+INSERT INTO orders (customer, amount) VALUES
+   ('Alice', 100.00),
+   ('Bob',   250.00),
+   ('Carol',  75.50);
+SELECT snowflake.convert_sequence_to_snowflake('orders_id_seq'::regclass);
+NOTICE:  EXECUTE ALTER TABLE public.orders ALTER COLUMN id SET DEFAULT snowflake.nextval('public.orders_id_seq'::regclass)
+NOTICE:  ALTER SEQUENCE public.orders_id_seq AS bigint NO CYCLE MAXVALUE 9223372036854775807
+ convert_sequence_to_snowflake 
+-------------------------------
+                             0
+(1 row)
+
+-- After conversion max_value MUST be the bigint ceiling, not (last_value+1).
+SELECT max_value = 9223372036854775807 AS max_is_bigint_max
+FROM pg_sequences WHERE sequencename = 'orders_id_seq';
+ max_is_bigint_max 
+-------------------
+ t
+(1 row)
+
+-- ----------------------------------------------------------------------
+-- 2. Generate a real snowflake-sized id; setval to that value must succeed
+--    (this is what pg_dump emits in the restore script).
+-- ----------------------------------------------------------------------
+INSERT INTO orders (customer, amount) VALUES ('Dave', 999) RETURNING id > 9999;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- A pg_catalog.setval() with a snowflake-sized value must NOT raise
+-- "out of bounds for sequence" any more.
+SELECT pg_catalog.setval('orders_id_seq', 4446196691613229056, true);
+       setval        
+---------------------
+ 4446196691613229056
+(1 row)
+
+SELECT last_value FROM orders_id_seq;
+     last_value      
+---------------------
+ 4446196691613229056
+(1 row)
+
+-- ----------------------------------------------------------------------
+-- 3. Plain (un-owned) sequence path.
+-- ----------------------------------------------------------------------
+CREATE SEQUENCE standalone_seq START 100;
+SELECT snowflake.convert_sequence_to_snowflake('standalone_seq'::regclass);
+NOTICE:  ALTER SEQUENCE public.standalone_seq AS bigint NO CYCLE MAXVALUE 9223372036854775807
+ convert_sequence_to_snowflake 
+-------------------------------
+                             0
+(1 row)
+
+SELECT max_value = 9223372036854775807 AS max_is_bigint_max
+FROM pg_sequences WHERE sequencename = 'standalone_seq';
+ max_is_bigint_max 
+-------------------
+ t
+(1 row)
+
+SELECT pg_catalog.setval('standalone_seq', 4446196691613229056, true);
+       setval        
+---------------------
+ 4446196691613229056
+(1 row)
+
+-- ----------------------------------------------------------------------
+-- Cleanup
+-- ----------------------------------------------------------------------
+DROP TABLE orders CASCADE;
+DROP SEQUENCE standalone_seq;
+DROP EXTENSION snowflake;

--- a/expected/repair.out
+++ b/expected/repair.out
@@ -1,0 +1,100 @@
+/*
+ * repair.sql - regression for the SUP-140 2.4->2.5 auto-repair.
+ *
+ * A sequence converted by the pre-2.5 code is left with a tiny MAXVALUE
+ * (old last_value + 1), while snowflake.nextval() bypasses MAXVALUE and
+ * writes snowflake-sized values into last_value.  The result is an
+ * internally inconsistent sequence (last_value > max_value) that pg_dump
+ * captures faithfully and that cannot be restored:
+ *
+ *   ERROR: setval: value <big_snowflake_id> is out of bounds for
+ *          sequence "<seq>" (1..<small>)
+ *
+ * The 2.4->2.5 upgrade script repairs such sequences automatically by
+ * widening MAXVALUE to the full bigint range.  This test builds the broken
+ * state under 2.4, upgrades to 2.5, and asserts the repair ran -- for both
+ * an owned (serial) sequence (detected by its snowflake.nextval column
+ * default) and a standalone sequence (detected by last_value > max_value).
+ */
+\set VERBOSITY terse
+CREATE EXTENSION snowflake VERSION '2.4';
+SET snowflake.node = 1;
+-- ----------------------------------------------------------------------
+-- Owned (bigserial) sequence: convert under 2.4 leaves the broken state.
+-- ----------------------------------------------------------------------
+CREATE TABLE orders (id bigserial PRIMARY KEY, customer text NOT NULL);
+INSERT INTO orders (customer) VALUES ('Alice'), ('Bob'), ('Carol');
+SELECT snowflake.convert_sequence_to_snowflake('orders_id_seq'::regclass);
+NOTICE:  EXECUTE ALTER TABLE public.orders ALTER COLUMN id SET DEFAULT snowflake.nextval('public.orders_id_seq'::regclass)
+NOTICE:  ALTER SEQUENCE public.orders_id_seq NO CYCLE MAXVALUE 4
+ convert_sequence_to_snowflake 
+-------------------------------
+                             0
+(1 row)
+
+-- Broken state: max_value is tiny and last_value already exceeds it.
+SELECT max_value < 9223372036854775807 AS max_is_low,
+       last_value > max_value          AS last_exceeds_max
+FROM pg_sequences WHERE sequencename = 'orders_id_seq';
+ max_is_low | last_exceeds_max 
+------------+------------------
+ t          | t
+(1 row)
+
+-- ----------------------------------------------------------------------
+-- Standalone sequence with a below-snowflake ceiling, driven directly via
+-- snowflake.nextval().  No column default marker, so the repair must detect
+-- it via the last_value > max_value signature.
+-- ----------------------------------------------------------------------
+CREATE SEQUENCE standalone_seq MAXVALUE 1000000;
+SELECT snowflake.nextval('standalone_seq') > 1000000 AS wrote_snowflake_id;
+ wrote_snowflake_id 
+--------------------
+ t
+(1 row)
+
+SELECT max_value < 9223372036854775807 AS max_is_low,
+       last_value > max_value          AS last_exceeds_max
+FROM pg_sequences WHERE sequencename = 'standalone_seq';
+ max_is_low | last_exceeds_max 
+------------+------------------
+ t          | t
+(1 row)
+
+-- ----------------------------------------------------------------------
+-- Upgrade to 2.5: the repair block runs automatically.  Suppress its
+-- NOTICEs so the test output does not depend on repair ordering.
+-- ----------------------------------------------------------------------
+SET client_min_messages = warning;
+ALTER EXTENSION snowflake UPDATE TO '2.5';
+RESET client_min_messages;
+-- Both sequences must now carry the full bigint ceiling.
+SELECT sequencename, max_value = 9223372036854775807 AS repaired
+FROM pg_sequences
+WHERE sequencename IN ('orders_id_seq', 'standalone_seq')
+ORDER BY sequencename;
+  sequencename  | repaired 
+----------------+----------
+ orders_id_seq  | t
+ standalone_seq | t
+(2 rows)
+
+-- A snowflake-sized setval (what pg_dump emits on restore) must now succeed.
+SELECT pg_catalog.setval('orders_id_seq', 4446196691613229056, true);
+       setval        
+---------------------
+ 4446196691613229056
+(1 row)
+
+SELECT pg_catalog.setval('standalone_seq', 4446196691613229056, true);
+       setval        
+---------------------
+ 4446196691613229056
+(1 row)
+
+-- ----------------------------------------------------------------------
+-- Cleanup
+-- ----------------------------------------------------------------------
+DROP TABLE orders CASCADE;
+DROP SEQUENCE standalone_seq;
+DROP EXTENSION snowflake;

--- a/snowflake--2.4--2.5.sql
+++ b/snowflake--2.4--2.5.sql
@@ -1,0 +1,313 @@
+/* snowflake--2.4--2.5.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION snowflake UPDATE TO '2.5'" to load this file. \quit
+
+-- ----------------------------------------------------------------------
+-- 2.4 -> 2.5 - fix MAXVALUE on snowflake-converted sequences.
+--
+-- The pre-2.5 convert_sequence_to_snowflake() set MAXVALUE to
+-- (old last_value + 1) when converting a sequence to snowflake IDs.
+-- The intent was to "lock out" pg_catalog.nextval(), but
+-- snowflake.nextval() bypasses MAXVALUE so the sequence happily
+-- generated huge snowflake IDs while the catalog still reported a
+-- tiny ceiling.  pg_dump captures both ("MAXVALUE 4" plus
+-- "SELECT pg_catalog.setval(..., 4446196691613229056, true)") and
+-- the resulting dump cannot be restored:
+--
+--   ERROR: setval: value 4446196691613229056 is out of bounds for
+--          sequence "orders_id_seq" (1..4)
+--
+-- 2.5 changes the sequence's data type to bigint and sets MAXVALUE to
+-- the full bigint range (2^63-1) so any snowflake ID and any
+-- pg_dump-emitted setval stays in bounds.  This script:
+--   1. Re-installs convert_sequence_to_snowflake() with the fix so
+--      future conversions store the correct MAXVALUE.
+--   2. Walks pg_sequences and raises MAXVALUE to 2^63-1 (and the
+--      sequence data type to bigint) on any sequence whose column
+--      default already uses snowflake.nextval() and whose max_value is
+--      below bigint MAX.
+-- ----------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION snowflake.convert_sequence_to_snowflake(p_seqid regclass)
+RETURNS integer
+SET search_path = pg_catalog
+AS $$
+DECLARE
+	v_objdesc			record; -- contains target (reloid,attnum) value
+	v_identdesc		record; -- sequence-related flags (attisidentity)
+	v_attrdef		record;
+	v_attr			record;
+	v_seq			record;
+	v_cmd			text;
+	v_num_altered	integer := 0;
+	v_seqname1		text;
+	v_extseqname		text;
+	v_is_serial_def	boolean;
+	v_textstr			text;
+BEGIN
+	-- Identify the (relation,attnum) that uses this sequence as a source
+	-- for values. Follow the logic of the getOwnedSequences_internal.
+	--
+	-- Complain, if such data wasn't found - incoming object may be not
+	-- a sequence, or sequence which is used for different purposes.
+	-- v_objdesc's fields:
+	-- heapreloid - Oid of the target relation.
+	-- nspname - namespace of the sequence
+	-- seqname - sequence name
+	-- attnum - number of relation's attribute that employs this sequence
+	SELECT INTO v_objdesc
+		refobjid AS heapreloid,
+		c.relnamespace::regnamespace::text AS nspname,
+		c.relname AS seqname,
+		refobjsubid AS attnum,
+		deptype
+	FROM pg_depend AS d JOIN pg_class AS c ON (d.objid = c.oid)
+	WHERE
+		classid = 'pg_class'::regclass AND
+		deptype IN ('a','i','n') AND
+		c.oid = p_seqid AND relkind = 'S'
+	ORDER BY deptype; -- prioritize (a)uto and (i)nternal before (n)ormal
+
+	IF (v_objdesc IS NULL) THEN
+		raise EXCEPTION 'Input value "%" is not a valid convertable sequence', p_seqid;
+		RETURN false;
+	END IF;
+
+	-- ----
+	-- We are looking for column defaults that use the requested
+	-- sequence and the function nextval(). Because pg_get_expr()
+	-- omits the schemaname of the sequence if it is "public" we
+	-- need to be prepared for a schema qualified and unqualified
+	-- name here.
+	-- ----
+	SELECT INTO v_seqname1
+		quote_ident(v_objdesc.seqname);
+	SELECT INTO v_extseqname
+		quote_ident(v_objdesc.nspname) || '.' || quote_ident(v_objdesc.seqname);
+
+	IF v_objdesc.deptype IN ('a','i') THEN
+		-- Handle IDENTITY case and SERIAL/BIGSERIAL case
+
+		SELECT INTO v_identdesc
+			(attidentity = 'a' OR attidentity = 'd') AS is_identity,
+			c.relnamespace::regnamespace::text AS nspname,
+			c.relname AS relname,
+			a.attname AS attname
+		FROM pg_attribute a JOIN pg_class c ON (c.oid = a.attrelid)
+		WHERE a.attrelid = v_objdesc.heapreloid AND a.attnum = v_objdesc.attnum;
+
+		IF (v_identdesc.is_identity) THEN
+			UPDATE pg_attribute SET attidentity = ''
+			WHERE attrelid = v_objdesc.heapreloid AND attnum = v_objdesc.attnum;
+			RAISE NOTICE
+				'Update pg_attribute: reset attidentity value for table %, column %',
+				v_objdesc.heapreloid::regclass, v_identdesc.attname;
+		ELSE
+
+			-- Extract DEFAULT definition for the column and conver it into
+			-- a readable string representation.
+			SELECT INTO v_textstr
+				pg_get_expr(ad.adbin, ad.adrelid, true)
+			FROM pg_attrdef ad
+			WHERE adrelid = v_objdesc.heapreloid AND adnum = v_objdesc.attnum;
+
+			-- Check that the DEFAULT expression contains input sequence in a form
+			-- as related to the serial and bigserial type.
+			SELECT INTO v_is_serial_def
+			CASE WHEN
+					v_textstr = 'nextval(' || quote_literal(v_seqname1) || '::regclass)' OR
+					v_textstr = 'nextval(' || quote_literal(v_extseqname) || '::regclass)'
+			THEN true ELSE false END;
+
+			-- If there is another DEFAULT expression already set for this column, we
+			-- are not so bold to remove it, just complain,
+			IF (NOT v_is_serial_def) THEN
+				raise EXCEPTION
+					'definition of DEFAULT value for column "%" of relation "%" does not correspond serial or bigserial type: "%"',
+					v_identdesc.attname, v_identdesc.relname, v_textstr;
+			END IF;
+		END IF;
+
+		-- ----
+		-- If the attribute type is not bigint, we change it
+		-- ----
+		v_num_altered =
+			snowflake.convert_column_to_int8(v_objdesc.heapreloid::regclass,
+										 v_objdesc.attnum::smallint);
+
+		-- ----
+		-- Now we can change the default to snowflake.nextval()
+		-- ----
+		v_cmd = 'ALTER TABLE ' ||
+			quote_ident(v_identdesc.nspname) || '.' ||
+			quote_ident(v_identdesc.relname) ||
+			' ALTER COLUMN ' || quote_ident(v_identdesc.attname) ||
+			' SET DEFAULT snowflake.nextval(' ||
+			quote_literal(
+				quote_ident(v_objdesc.nspname) || '.' ||
+				quote_ident(v_objdesc.seqname)
+			) || '::regclass)';
+		RAISE NOTICE 'EXECUTE %', v_cmd;
+		EXECUTE v_cmd;
+	ELSE
+		-- Look for cases where the sequence is used as an explicit default value
+
+		FOR v_attrdef IN
+			WITH AD AS (
+				SELECT AD.*,
+					   pg_get_expr(AD.adbin, AD.adrelid, true) adstr
+				FROM pg_attrdef AD
+			)
+			SELECT * FROM AD
+			WHERE AD.adstr = 'nextval(' || quote_literal(v_seqname1) || '::regclass)'
+			   OR AD.adstr = 'nextval(' || quote_literal(v_extseqname) || '::regclass)'
+		LOOP
+			-- ----
+			-- Get the attribute definition
+			-- ----
+			SELECT * INTO v_attr
+			FROM pg_namespace N
+			JOIN pg_class C
+				ON N.oid = C.relnamespace
+			JOIN pg_attribute A
+				ON C.oid = A.attrelid
+			WHERE A.attrelid = v_attrdef.adrelid
+				AND A.attnum = v_attrdef.adnum;
+
+			IF NOT FOUND THEN
+				RAISE EXCEPTION 'Attribute for % not found', v_attrdef.adstr;
+			END IF;
+
+			-- ----
+			-- Get the sequence definition
+			-- ----
+			SELECT * INTO v_seq
+			FROM pg_namespace N
+			JOIN pg_class C
+				ON N.oid = C.relnamespace
+			WHERE C.oid = p_seqid;
+
+			IF NOT FOUND THEN
+				RAISE EXCEPTION 'Sequence with Oid % not found', p_seqid;
+			END IF;
+
+			-- ----
+			-- If the attribute type is not bigint, we change it
+			-- ----
+			v_num_altered = v_num_altered +
+				snowflake.convert_column_to_int8(v_attr.attrelid, v_attr.attnum);
+
+			-- ----
+			-- Now we can change the default to snowflake.nextval()
+			-- ----
+			v_cmd = 'ALTER TABLE ' ||
+				quote_ident(v_attr.nspname) || '.' ||
+				quote_ident(v_attr.relname) ||
+				' ALTER COLUMN ' ||
+				quote_ident(v_attr.attname) ||
+				' SET DEFAULT snowflake.nextval(' ||
+				quote_literal(
+					quote_ident(v_seq.nspname) || '.' ||
+					quote_ident(v_seq.relname)
+				) ||
+				'::regclass)';
+			RAISE NOTICE 'EXECUTE %', v_cmd;
+			EXECUTE v_cmd;
+
+			v_num_altered = v_num_altered + 1;
+		END LOOP;
+	END IF;
+
+	-- Note: for plain sequences not associated with columns, we still
+	-- fall through to here so snowflake can be used, to support
+	-- sequences used explicitly by applications
+
+	-- ----
+	-- Finally bump the sequence past its current last_value by
+	-- invoking snowflake.nextval().  The MAXVALUE is left at the
+	-- full bigint range (2^63-1) so subsequent snowflake IDs - and
+	-- the pg_catalog.setval() calls that pg_dump emits during a
+	-- restore - all stay within bounds.
+	-- ----
+	v_cmd = 'ALTER SEQUENCE ' ||
+		pg_catalog.quote_ident(N.nspname) || '.' ||
+		pg_catalog.quote_ident(C.relname) ||
+		' AS bigint NO CYCLE MAXVALUE 9223372036854775807'
+		FROM pg_catalog.pg_class C
+		JOIN pg_catalog.pg_namespace N ON N.oid = C.relnamespace
+		WHERE C.oid = p_seqid;
+	RAISE NOTICE '%', v_cmd;
+	EXECUTE v_cmd;
+
+	PERFORM snowflake.nextval(p_seqid);
+	RETURN v_num_altered;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ----------------------------------------------------------------------
+-- One-shot repair: raise MAXVALUE to 2^63-1 on every sequence that was
+-- already converted to snowflake but still has the old, low ceiling.
+--
+-- convert_sequence_to_snowflake() supports three flavors of sequence
+-- and the repair has to cover all three:
+--   1. SERIAL / BIGSERIAL / IDENTITY  (pg_depend.deptype = 'a' or 'i')
+--   2. Plain sequence used via an explicit nextval() column DEFAULT
+--      (pg_depend.deptype = 'n')
+--   3. Standalone sequence with no associated column, used directly
+--      via snowflake.nextval('seq_name').
+--
+-- Flavors (1) and (2) are detected by the column DEFAULT being rewritten
+-- to snowflake.nextval(...).  Flavor (3) leaves no such marker on a
+-- column, so we detect it by the inconsistent on-disk state the bug
+-- produces: last_value > max_value, which cannot occur in normal
+-- PostgreSQL operation and is the unique signature of a pre-2.5
+-- conversion of a standalone sequence.
+-- ----------------------------------------------------------------------
+DO $repair$
+DECLARE
+	r record;
+	v_cmd text;
+BEGIN
+	FOR r IN
+		-- Flavors 1 + 2: owned or explicit-default sequences whose
+		-- column DEFAULT now references snowflake.nextval(...)
+		SELECT n.nspname AS seq_nspname,
+		       c.relname AS seq_relname,
+		       s.max_value
+		FROM pg_class c
+		JOIN pg_namespace n   ON n.oid = c.relnamespace
+		JOIN pg_sequences s   ON s.schemaname = n.nspname
+		                     AND s.sequencename = c.relname
+		JOIN pg_depend d      ON d.objid = c.oid
+		                     AND d.classid = 'pg_class'::regclass
+		                     AND d.deptype IN ('a','i','n')
+		JOIN pg_attrdef ad    ON ad.adrelid = d.refobjid
+		                     AND ad.adnum   = d.refobjsubid
+		WHERE c.relkind = 'S'
+		  AND s.max_value < 9223372036854775807
+		  AND pg_get_expr(ad.adbin, ad.adrelid, true) LIKE '%snowflake.nextval(%'
+		UNION
+		-- Flavor 3: standalone sequence with no rewritten column DEFAULT.
+		-- last_value > max_value is the unique signature of a pre-2.5
+		-- conversion (snowflake.nextval bypasses MAXVALUE, so the value
+		-- stored is well beyond the recorded ceiling).
+		SELECT n.nspname AS seq_nspname,
+		       c.relname AS seq_relname,
+		       s.max_value
+		FROM pg_class c
+		JOIN pg_namespace n  ON n.oid = c.relnamespace
+		JOIN pg_sequences s  ON s.schemaname = n.nspname
+		                    AND s.sequencename = c.relname
+		WHERE c.relkind = 'S'
+		  AND s.max_value < 9223372036854775807
+		  AND s.last_value IS NOT NULL
+		  AND s.last_value > s.max_value
+	LOOP
+		v_cmd := format('ALTER SEQUENCE %I.%I AS bigint NO CYCLE MAXVALUE 9223372036854775807',
+		                r.seq_nspname, r.seq_relname);
+		RAISE NOTICE 'snowflake 2.4->2.5 repair: % (was max_value=%)', v_cmd, r.max_value;
+		EXECUTE v_cmd;
+	END LOOP;
+END
+$repair$;

--- a/snowflake.control
+++ b/snowflake.control
@@ -1,6 +1,6 @@
 # snowflake extension
 comment = 'Snowflake style IDs for PostgreSQL'
-default_version = '2.4'
+default_version = '2.5'
 module_pathname = '$libdir/snowflake'
 relocatable = false
 schema = snowflake

--- a/sql/conversion.sql
+++ b/sql/conversion.sql
@@ -107,6 +107,10 @@ SELECT * FROM t6;
 INSERT INTO t6 VALUES (DEFAULT, 30);
 SELECT * FROM t6;
 SELECT snowflake.convert_sequence_to_snowflake('t6_x_seq');
+-- Start from a fresh millisecond so the counter base is 0 regardless of how
+-- the preceding calls happened to land in time. Without this the exact count
+-- values below depend on millisecond boundaries and the test is flaky.
+SELECT pg_sleep(0.5);
 -- Get the count portion of the id.
 -- It happens within the same milisecond, should increment
 SELECT snowflake.get_count(snowflake.nextval('t6_x_seq'))
@@ -120,6 +124,8 @@ SELECT ABS(snowflake.nextval('t6_x_seq') - snowflake.nextval('t6_x_seq'));
 
 -- If < 4096, will increment that amount
 ALTER SEQUENCE t6_x_seq INCREMENT 100 NO MAXVALUE;
+-- Again start from a fresh millisecond for a deterministic counter base.
+SELECT pg_sleep(0.5);
 SELECT snowflake.get_count(snowflake.nextval('t6_x_seq'))
 UNION ALL
 SELECT snowflake.get_count(snowflake.nextval('t6_x_seq'))

--- a/sql/maxvalue.sql
+++ b/sql/maxvalue.sql
@@ -1,0 +1,68 @@
+/*
+ * maxvalue.sql - regression for the SUP-140 dump/restore failure.
+ *
+ * Before the fix, convert_sequence_to_snowflake() set
+ *   ALTER SEQUENCE ... MAXVALUE (last_value + 1)
+ * which is fine for the snowflake.nextval() path (it bypasses MAXVALUE)
+ * but fatal for pg_dump/restore: the dump captures the resulting
+ * snowflake-sized last_value via pg_catalog.setval(...) and the
+ * restore is rejected with
+ *   ERROR: setval: value <big_snowflake_id> is out of bounds for
+ *          sequence "<seq>" (1..<small>)
+ *
+ * This test asserts that after conversion the sequence's max_value is
+ * the full bigint range (2^63-1).
+ */
+
+\set VERBOSITY terse
+
+SET snowflake.node = 1;
+
+CREATE EXTENSION snowflake;
+
+-- ----------------------------------------------------------------------
+-- 1. Customer reproducer: bigserial table, INSERT, convert.
+-- ----------------------------------------------------------------------
+CREATE TABLE orders (
+    id    bigserial PRIMARY KEY,
+    customer text   NOT NULL,
+    amount  numeric  NOT NULL
+);
+INSERT INTO orders (customer, amount) VALUES
+   ('Alice', 100.00),
+   ('Bob',   250.00),
+   ('Carol',  75.50);
+
+SELECT snowflake.convert_sequence_to_snowflake('orders_id_seq'::regclass);
+
+-- After conversion max_value MUST be the bigint ceiling, not (last_value+1).
+SELECT max_value = 9223372036854775807 AS max_is_bigint_max
+FROM pg_sequences WHERE sequencename = 'orders_id_seq';
+
+-- ----------------------------------------------------------------------
+-- 2. Generate a real snowflake-sized id; setval to that value must succeed
+--    (this is what pg_dump emits in the restore script).
+-- ----------------------------------------------------------------------
+INSERT INTO orders (customer, amount) VALUES ('Dave', 999) RETURNING id > 9999;
+
+-- A pg_catalog.setval() with a snowflake-sized value must NOT raise
+-- "out of bounds for sequence" any more.
+SELECT pg_catalog.setval('orders_id_seq', 4446196691613229056, true);
+
+SELECT last_value FROM orders_id_seq;
+
+-- ----------------------------------------------------------------------
+-- 3. Plain (un-owned) sequence path.
+-- ----------------------------------------------------------------------
+CREATE SEQUENCE standalone_seq START 100;
+SELECT snowflake.convert_sequence_to_snowflake('standalone_seq'::regclass);
+SELECT max_value = 9223372036854775807 AS max_is_bigint_max
+FROM pg_sequences WHERE sequencename = 'standalone_seq';
+SELECT pg_catalog.setval('standalone_seq', 4446196691613229056, true);
+
+-- ----------------------------------------------------------------------
+-- Cleanup
+-- ----------------------------------------------------------------------
+DROP TABLE orders CASCADE;
+DROP SEQUENCE standalone_seq;
+DROP EXTENSION snowflake;

--- a/sql/repair.sql
+++ b/sql/repair.sql
@@ -1,0 +1,71 @@
+/*
+ * repair.sql - regression for the SUP-140 2.4->2.5 auto-repair.
+ *
+ * A sequence converted by the pre-2.5 code is left with a tiny MAXVALUE
+ * (old last_value + 1), while snowflake.nextval() bypasses MAXVALUE and
+ * writes snowflake-sized values into last_value.  The result is an
+ * internally inconsistent sequence (last_value > max_value) that pg_dump
+ * captures faithfully and that cannot be restored:
+ *
+ *   ERROR: setval: value <big_snowflake_id> is out of bounds for
+ *          sequence "<seq>" (1..<small>)
+ *
+ * The 2.4->2.5 upgrade script repairs such sequences automatically by
+ * widening MAXVALUE to the full bigint range.  This test builds the broken
+ * state under 2.4, upgrades to 2.5, and asserts the repair ran -- for both
+ * an owned (serial) sequence (detected by its snowflake.nextval column
+ * default) and a standalone sequence (detected by last_value > max_value).
+ */
+
+\set VERBOSITY terse
+
+CREATE EXTENSION snowflake VERSION '2.4';
+SET snowflake.node = 1;
+
+-- ----------------------------------------------------------------------
+-- Owned (bigserial) sequence: convert under 2.4 leaves the broken state.
+-- ----------------------------------------------------------------------
+CREATE TABLE orders (id bigserial PRIMARY KEY, customer text NOT NULL);
+INSERT INTO orders (customer) VALUES ('Alice'), ('Bob'), ('Carol');
+SELECT snowflake.convert_sequence_to_snowflake('orders_id_seq'::regclass);
+
+-- Broken state: max_value is tiny and last_value already exceeds it.
+SELECT max_value < 9223372036854775807 AS max_is_low,
+       last_value > max_value          AS last_exceeds_max
+FROM pg_sequences WHERE sequencename = 'orders_id_seq';
+
+-- ----------------------------------------------------------------------
+-- Standalone sequence with a below-snowflake ceiling, driven directly via
+-- snowflake.nextval().  No column default marker, so the repair must detect
+-- it via the last_value > max_value signature.
+-- ----------------------------------------------------------------------
+CREATE SEQUENCE standalone_seq MAXVALUE 1000000;
+SELECT snowflake.nextval('standalone_seq') > 1000000 AS wrote_snowflake_id;
+SELECT max_value < 9223372036854775807 AS max_is_low,
+       last_value > max_value          AS last_exceeds_max
+FROM pg_sequences WHERE sequencename = 'standalone_seq';
+
+-- ----------------------------------------------------------------------
+-- Upgrade to 2.5: the repair block runs automatically.  Suppress its
+-- NOTICEs so the test output does not depend on repair ordering.
+-- ----------------------------------------------------------------------
+SET client_min_messages = warning;
+ALTER EXTENSION snowflake UPDATE TO '2.5';
+RESET client_min_messages;
+
+-- Both sequences must now carry the full bigint ceiling.
+SELECT sequencename, max_value = 9223372036854775807 AS repaired
+FROM pg_sequences
+WHERE sequencename IN ('orders_id_seq', 'standalone_seq')
+ORDER BY sequencename;
+
+-- A snowflake-sized setval (what pg_dump emits on restore) must now succeed.
+SELECT pg_catalog.setval('orders_id_seq', 4446196691613229056, true);
+SELECT pg_catalog.setval('standalone_seq', 4446196691613229056, true);
+
+-- ----------------------------------------------------------------------
+-- Cleanup
+-- ----------------------------------------------------------------------
+DROP TABLE orders CASCADE;
+DROP SEQUENCE standalone_seq;
+DROP EXTENSION snowflake;

--- a/test/t/snowflake_dump_restore.sh
+++ b/test/t/snowflake_dump_restore.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+#
+# snowflake_dump_restore.sh
+#
+# End-to-end regression for the SUP-140 dump/restore failure.
+#
+# A sequence converted to snowflake must survive a full pg_dump + restore.
+# Before the 2.5 fix, convert_sequence_to_snowflake() left MAXVALUE at
+# (old last_value + 1) while snowflake.nextval() bypasses MAXVALUE and writes
+# snowflake-sized values into last_value.  pg_dump then emitted a huge
+# setval() against a tiny ceiling and the restore aborted with:
+#
+#   ERROR: setval: value <big_snowflake_id> is out of bounds for
+#          sequence "orders_id_seq" (1..<small>)
+#
+# This test builds a converted sequence, dumps it, restores into a fresh
+# database, and verifies the data and sequence position survive intact.
+#
+# NOTE: intentionally NOT listed in test/schedule_files/script_file.  Run it
+# explicitly:  python runner.py -c <config.env> -t test/t/snowflake_dump_restore.sh
+#
+set -euo pipefail
+
+# Locate the n1 binaries / connection params the way runner.py does, falling
+# back to PATH and defaults so the script also runs outside the harness.
+PGBIN="${EDGE_CLUSTER_DIR:-}/n1/pgedge/${EDGE_COMPONENT:-pg17}/bin"
+[ -x "$PGBIN/psql" ] || PGBIN=""
+PSQL="${PGBIN:+$PGBIN/}psql"
+PGDUMP="${PGBIN:+$PGBIN/}pg_dump"
+CREATEDB="${PGBIN:+$PGBIN/}createdb"
+DROPDB="${PGBIN:+$PGBIN/}dropdb"
+
+HOST="${EDGE_HOST:-127.0.0.1}"
+PORT="${EDGE_START_PORT:-5432}"
+SUPERUSER="${PGSUPERUSER:-postgres}"
+
+CONN=( -h "$HOST" -p "$PORT" -U "$SUPERUSER" )
+RUN=( "$PSQL" -X -q -v ON_ERROR_STOP=1 "${CONN[@]}" )
+
+SRC=snowflake_dump_src
+DST=snowflake_dump_dst
+DUMP="$(mktemp "/tmp/snowflake_dump.XXXXXX.sql")"
+
+cleanup() {
+    "$DROPDB" "${CONN[@]}" --if-exists "$SRC" >/dev/null 2>&1 || true
+    "$DROPDB" "${CONN[@]}" --if-exists "$DST" >/dev/null 2>&1 || true
+    rm -f "$DUMP"
+}
+trap cleanup EXIT
+
+echo "# building source database with a converted bigserial sequence"
+"$DROPDB" "${CONN[@]}" --if-exists "$SRC" >/dev/null 2>&1 || true
+"$CREATEDB" "${CONN[@]}" "$SRC"
+"${RUN[@]}" -d "$SRC" <<'SQL'
+CREATE EXTENSION snowflake;
+SET snowflake.node = 1;
+CREATE TABLE orders (id bigserial PRIMARY KEY, customer text NOT NULL);
+INSERT INTO orders (customer) VALUES ('Alice'), ('Bob'), ('Carol');
+SELECT snowflake.convert_sequence_to_snowflake('orders_id_seq'::regclass);
+-- Produce a real snowflake-sized id so the dump's setval() is huge.
+INSERT INTO orders (customer) VALUES ('Dave');
+SQL
+
+src_count="$("${RUN[@]}" -At -d "$SRC" -c "SELECT count(*) FROM orders;")"
+src_last="$("${RUN[@]}" -At -d "$SRC" -c "SELECT last_value FROM orders_id_seq;")"
+echo "# source: ${src_count} rows, sequence last_value=${src_last}"
+
+echo "# dump + restore into a fresh database"
+"$PGDUMP" "${CONN[@]}" "$SRC" > "$DUMP"
+"$DROPDB" "${CONN[@]}" --if-exists "$DST" >/dev/null 2>&1 || true
+"$CREATEDB" "${CONN[@]}" "$DST"
+# With the bug this aborts on the out-of-bounds setval; ON_ERROR_STOP makes
+# that a hard failure of this test.
+"${RUN[@]}" -d "$DST" -f "$DUMP" >/dev/null
+
+dst_count="$("${RUN[@]}" -At -d "$DST" -c "SELECT count(*) FROM orders;")"
+dst_last="$("${RUN[@]}" -At -d "$DST" -c "SELECT last_value FROM orders_id_seq;")"
+echo "# restored: ${dst_count} rows, sequence last_value=${dst_last}"
+
+if [ "$src_count" != "$dst_count" ] || [ "$src_last" != "$dst_last" ]; then
+    echo "FAIL: restored state differs from source"
+    exit 1
+fi
+
+# The restored sequence must still mint snowflake ids for new inserts.
+new_id="$("${RUN[@]}" -At -d "$DST" -c "SET snowflake.node = 1; INSERT INTO orders (customer) VALUES ('Eve') RETURNING id;")"
+if [ "$new_id" -le "$src_last" ]; then
+    echo "FAIL: post-restore insert id ${new_id} did not advance past ${src_last}"
+    exit 1
+fi
+
+echo "PASS: dump/restore preserved ${dst_count} rows; sequence intact and still minting (new id ${new_id})"


### PR DESCRIPTION
convert_sequence_to_snowflake() previously set MAXVALUE to (old last_value + 1).  snowflake.nextval() bypasses MAXVALUE, so the sequence stored huge snowflake IDs against a tiny ceiling; pg_dump then captured both, and the restore failed with
"setval: value <snowflake_id> is out of bounds for sequence ...".

Fix in every embedded copy: ALTER SEQUENCE ... AS bigint NO CYCLE MAXVALUE 9223372036854775807.  AS bigint keeps the fix safe for int4-backed serial sequences.

Adds snowflake--2.4--2.5.sql which re-installs the corrected function and repairs already-converted sequences in existing databases. Bumps default_version to 2.5.  Regression test sql/maxvalue.sql exercises the pg_dump setval path.