### PR TITLE
Port snowflake to PostgreSQL 19

### DIFF
--- a/snowflake.c
+++ b/snowflake.c
@@ -16,6 +16,8 @@
 
 #include "postgres.h"
 
+#include <time.h>
+
 #include "access/bufmask.h"
 #include "access/htup_details.h"
 #include "access/multixact.h"
@@ -35,6 +37,9 @@
 #include "catalog/storage_xlog.h"
 #include "commands/defrem.h"
 #include "commands/sequence.h"
+#if PG_VERSION_NUM >= 190000
+#include "commands/sequence_xlog.h"
+#endif
 #include "commands/tablecmds.h"
 #include "funcapi.h"
 #include "miscadmin.h"
@@ -61,6 +66,7 @@ PG_MODULE_MAGIC;
  */
 #define SEQ_LOG_VALS	32
 
+#if PG_VERSION_NUM < 190000
 /*
  * The "special area" of a sequence's buffer page looks like this.
  */
@@ -70,6 +76,7 @@ typedef struct sequence_magic
 {
 	uint32		magic;
 } sequence_magic;
+#endif
 
 /*
  * We store a SeqTable item for every sequence we have touched in the current
@@ -186,7 +193,6 @@ snowflake_nextval(PG_FUNCTION_ARGS)
 		ereport(ERROR,
 				(errcode(ERRCODE_CONFIG_FILE_ERROR),
 				 errmsg("value for snowflake.node is not set")));
-		
 
 	/* open and lock sequence */
 	init_sequence(relid, &elm, &seqrel);


### PR DESCRIPTION
## Summary

Adapts the `snowflake` extension to build against PostgreSQL 19, tracking two upstream changes in the PG19 development cycle. All changes are guarded by `PG_VERSION_NUM` so the module continues to compile on PG ≤18.

## Changes

### 1. Sequence WAL definitions moved to a new header

PG19 commit `a87987cafca` ("Move WAL sequence code into its own file") split the sequence WAL definitions out of `commands/sequence.h` into a new `commands/sequence_xlog.h`. The symbols `SEQ_MAGIC`, `sequence_magic`, `xl_seq_rec` and `XLOG_SEQ_LOG` — all used by `snowflake_nextval()` and `read_seq_tuple()` — now live there.

- Include `commands/sequence_xlog.h` on PG19+ (guarded, since the header does not exist on earlier branches).
- Guard the module's local `SEQ_MAGIC` define and `sequence_magic` struct behind `#if PG_VERSION_NUM < 190000`, so on PG19 they resolve solely from the upstream header and there is no duplicate-definition conflict. On ≤18 the header never exported them, so the local definitions are still required.

### 2. `<time.h>` no longer reached transitively

`snowflake_nextval()` calls `clock_gettime(CLOCK_REALTIME, ...)`. On PG ≤18 the system `<time.h>` was pulled in transitively through the backend header chain; PG19 header-dependency cleanups (the `instr_time.h` TSC rework and removal of the `clock_gettime` configure probe) removed that path. Verified: without the include, PG19 fails with `call to undeclared function 'clock_gettime'` / `undeclared identifier 'CLOCK_REALTIME'`, and no other included header provides the declaration.

Added an explicit `#include <time.h>` — the standard "include what you use" fix, applied unconditionally as it is harmless on all supported branches.
