### PR TITLE
docs: remove deprecated CLI from Snowflake docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ USE_PGXS=1 make
 USE_PGXS=1 make install
 ```
 
-After installing the Snowflake extension with the pgEdge binary or from source code, connect to your Postgres database and create the extension with the command:
+After installing the Snowflake extension with your pgEdge deployment or from source code, connect to your Postgres database and create the extension with the command:
 
 ```
 CREATE EXTENSION snowflake;

--- a/docs/creating.md
+++ b/docs/creating.md
@@ -1,53 +1,42 @@
 # Creating a Snowflake Sequence in a New Cluster
 
-Before using Snowflake sequences, each node in your cluster must be assigned a unique `snowflake.node` identity in the `postgresql.conf` file. There are three ways to set the value of `snowflake.node`. You can:
+Before you use Snowflake sequences, each node in your cluster must have a unique `snowflake.node` identifier. The value ranges from 1 to 1023, and it must be distinct on every node in the cluster.
 
-* use the `pgedge spock node-create` command.
-* use the `pgedge db guc-set snowflake.node` command.
-* manually modify the `postgresql.conf` file.
+## Setting snowflake.node in a managed deployment
 
-If your cluster has 9 nodes (or fewer), and you use the node naming convention `N1`, `N2`, `N3` for your nodes, the `pgedge spock node-create` command will set the `snowflake.node` value for you. When you invoke the `pgedge spock node-create` command to define a new node, the value of `snowflake.node` is displayed after the command confirmation:
+A pgEdge deployment assigns `snowflake.node` for you, deriving the value from each node's place in the cluster:
 
-```sh
-[pgedge]$ ./pgedge spock node-create n2 'host=10.2.1.2 user=pgedge port=5432 dbname=acctg' acctg
+* the Control Plane sets `snowflake.node` from the node ordinal.
+* pgEdge Helm charts derive `snowflake.node` from each node name.
+* pgEdge Ansible playbooks set `snowflake.node` from the node zone.
 
-[
-  {
-	"node_create": 560818415
-  }
-]
-  new: snowflake.node = 2
+When you deploy with one of these methods, no further action is needed to configure the node identifier.
+
+## Setting snowflake.node manually
+
+For a self-managed or from-source installation, set the value yourself. Use `ALTER SYSTEM` to assign a unique node number, then reload the server so the change takes effect. The following example sets the node identifier to `10`:
+
+```sql
+ALTER SYSTEM SET snowflake.node = 10;
+SELECT pg_reload_conf();
 ```
 
-If you have a cluster with more than 9 nodes or a different node naming convention (other than N1, N2, etc.), you can use the `pgedge db guc-set` command to manually set `snowflake.node` to a numeric value that is unique within your cluster. The syntax is:
+You can also add the parameter to the `postgresql.conf` file directly. The following line identifies the host as node `11`:
 
-`[pgedge]$ ./pgedge database_name guc-set snowflake.node node_number`
-
-**Where**
-
-`node_number` is a unique number associated with the node. For example, the following command sets the `snowflake.node` value to `10`:
-
-```sh
-[pgedge]$ ./pgedge acctg guc-set snowflake.node 10
-```
-You also have the option to manually edit the `postgresql.conf` file, adding the value of `snowflake.node`. For example, you can add the following statement at the end of the file to identify the host as node `11`:
-
-```sh
+```ini
 snowflake.node = 11
 ```
 
-After setting the node identifier, you need to reload the server before using a Snowflake sequence.  You can use the `pgedge reload` command:
+After you edit `postgresql.conf`, reload the server for the change to take effect. You can reload from psql:
 
-```sh
-[pgedge]$ ./pgedge reload pg16
-pg16 reloading
+```sql
+SELECT pg_reload_conf();
 ```
 
-or use the `pg_ctl reload` command to reload the server:
+You can also reload the server with `pg_ctl`:
 
 ```sh
-[pgedge]$ /home/pgedge/pg16/bin/pg_ctl reload -D "/home/pgedge/data/pg16"
-server signaled
+pg_ctl reload -D "/path/to/your/data/directory"
 ```
 
-Once snowflake is configured, you can begin to use snowflake sequences by first [converting](converting.md) them from Postgres sequences.
+Once Snowflake is configured, you can begin to use Snowflake sequences by first [converting](converting.md) them from Postgres sequences.


### PR DESCRIPTION
## What

The pgEdge CLI is deprecated, but the Snowflake docs still instruct
users to configure `snowflake.node` with `./pgedge` commands. This
rewrites those instructions to be deployment-aware and SQL-based.

### `docs/creating.md`
- Removes the CLI-driven `pgedge spock node-create`, `pgedge db
  guc-set`, and `pgedge reload` steps (and the "9 nodes or fewer"
  auto-numbering narrative that only existed because of the CLI).
- Adds a "managed deployment" section: the Control Plane (node
  ordinal), Helm charts (node name), and Ansible (zone) each set
  `snowflake.node` automatically.
- Adds a "manual" section using `ALTER SYSTEM SET snowflake.node`
  plus `SELECT pg_reload_conf();`, keeping `pg_ctl reload` as the
  shell alternative.

### `README.md`
- Drops the "pgEdge binary" install phrasing in favor of "your
  pgEdge deployment or from source".

## Verification
- `snowflake.node` range (1-1023) and `PGC_SUSET` context confirmed
  against `snowflake.c`.
- Per-platform node numbering confirmed in control-plane, pgedge-helm,
  and pgedge-ansible.
- No residual `./pgedge` / CLI references remain in the docs.

Targets `main`; picked up by the next tagged Snowflake release.